### PR TITLE
 make sure all page creation flows use “createNewPage”

### DIFF
--- a/RIGImageGallery.podspec
+++ b/RIGImageGallery.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RIGImageGallery"
-  s.version          = "0.3.0"
+  s.version          = "0.3.1"
   s.summary          = "An image gallery view controller designed to work with the Raizlabs Interface Guidelines for iOS."
 
   s.description      = <<-DESC

--- a/RIGImageGallery/Assets/Info.plist
+++ b/RIGImageGallery/Assets/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RIGImageGallery/RIGImageGalleryViewController.swift
+++ b/RIGImageGallery/RIGImageGalleryViewController.swift
@@ -301,7 +301,7 @@ private extension RIGImageGalleryViewController {
         navigationController?.setToolbarHidden(navigationBarsHidden, animated: animated)
         navigationController?.setNavigationBarHidden(navigationBarsHidden, animated: animated)
         setNeedsStatusBarAppearanceUpdate()
-        UIView.animate(withDuration: 0.15, animations: {
+        UIView.animate(withDuration: 0.2, animations: {
             self.currentImageViewController?.scrollView.baseInsets = self.scrollViewInset
         })
     }

--- a/RIGImageGallery/RIGImageGalleryViewController.swift
+++ b/RIGImageGallery/RIGImageGalleryViewController.swift
@@ -87,7 +87,7 @@ open class RIGImageGalleryViewController: UIPageViewController {
             setViewControllers([UIViewController()], direction: .forward, animated: animated, completion: nil)
             return
         }
-        let newView = RIGSingleImageViewController(viewerItem: images[currentImage])
+        let newView = createNewPage(for: images[currentImage])
         let direction: UIPageViewControllerNavigationDirection
         if self.currentImage < currentImage {
             direction = .forward
@@ -162,7 +162,7 @@ open class RIGImageGalleryViewController: UIPageViewController {
         super.viewWillAppear(animated)
         updateBarStatus(animated: false)
         if currentImage < images.count {
-            let photoPage =  RIGSingleImageViewController(viewerItem: images[currentImage])
+            let photoPage = createNewPage(for: images[currentImage])
             setViewControllers([photoPage], direction: .forward, animated: false, completion: nil)
         }
     }

--- a/RIGImageGalleryDemo/Assets/Info.plist
+++ b/RIGImageGalleryDemo/Assets/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
minor fix to make sure all paths use the function to create a gallery item for better loading indicator overriding
